### PR TITLE
(Feat) Initialise table properly even if db file is corrupted.

### DIFF
--- a/helpers/dbHelper.js
+++ b/helpers/dbHelper.js
@@ -13,20 +13,17 @@ module.exports = {
    * already exist
    */
   ensureDatabase: () => {
-    const dbExists = fs.existsSync(dbFile);
     const db = new sqlite3.Database(dbFile);
     const createSubscriptionStatement =
-      'CREATE TABLE Subscription (' +
+      'CREATE TABLE IF NOT EXISTS Subscription (' +
       'SubscriptionId TEXT NOT NULL, ' +
       'UserAccountId TEXT NOT NULL' +
       ')';
 
     db.serialize(() => {
-      if (!dbExists) {
-        db.run(createSubscriptionStatement, (error) => {
-          if (error) throw error;
-        });
-      }
+      db.run(createSubscriptionStatement, (error) => {
+        if (error) throw error;
+      });
     });
 
     db.close();


### PR DESCRIPTION
If the table sql table isn't created properly, then the program will fail because `ensureDatabase()` will think that the table already exists because the database already exists. 

This is highly prone to failure, because when the authentication isn't completed successfully, it can create a database that doesn't have a table. 

The improvement is to use a `CREATE TABLE IF NOT EXISTS` sql statement so that the table can be created, even if the database exists without a sql table. 